### PR TITLE
Upgrade clipboard-rs version to fix clipboard image bug. Bump to v0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tauri-plugin-clipboard"
 license = "MIT"
-version = "0.6.1"
+version = "0.6.2"
 description = "A clipboard plugin for Tauri that supports text, files and image, as well as clipboard update listening."
 authors = [ "Huakun" ]
 edition = "2021"
@@ -17,4 +17,4 @@ clipboard-master = "3.1.3"
 base64 = "0.21.5"
 tempfile = "3.8.1"
 image = "0.24.7"
-clipboard-rs = "0.1.4"
+clipboard-rs = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ tauri-plugin-clipboard = { git = "https://github.com/CrossCopy/tauri-plugin-clip
 You can also add a tag to github url.
 
 ```toml
-tauri-plugin-clipboard = { git = "https://github.com/CrossCopy/tauri-plugin-clipboard", tag = "v0.6.0" }
+tauri-plugin-clipboard = { git = "https://github.com/CrossCopy/tauri-plugin-clipboard", tag = "v0.6.2" }
 ```
 
 NPM Package: https://www.npmjs.com/package/tauri-plugin-clipboard-api
@@ -33,7 +33,7 @@ npm i tauri-plugin-clipboard-api
 
 npm i https://github.com/CrossCopy/tauri-plugin-clipboard # or this for latest unpublished version (not recommended)
 
-npm i https://github.com/CrossCopy/tauri-plugin-clipboard#v0.6.0 # or this for tag
+npm i https://github.com/CrossCopy/tauri-plugin-clipboard#v0.6.2 # or this for tag
 ```
 
 In `main.rs`, add the following to your `tauri::Builder`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-plugin-clipboard-api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Huakun Shen",
   "type": "module",
   "description": "",


### PR DESCRIPTION
previous clipboard-rs had problem reading image on win11. Fixed now.

Related issues:
- https://github.com/CrossCopy/tauri-plugin-clipboard/issues/21
- https://github.com/ChurchTao/clipboard-rs/issues/14