### PR TITLE
upgrade clipboard-rs to 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tauri-plugin-clipboard"
 license = "MIT"
-version = "1.1.3"
+version = "1.1.4"
 description = "A clipboard plugin for Tauri that supports text, files and image, as well as clipboard update listening."
 authors = [ "Huakun" ]
 edition = "2021"
@@ -16,4 +16,4 @@ thiserror = "1.0"
 base64 = "0.21.5"
 tempfile = "3.8.1"
 image = "0.24.7"
-clipboard-rs = "0.1.7"
+clipboard-rs = "0.1.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-plugin-clipboard-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "Huakun Shen",
   "type": "module",
   "description": "",


### PR DESCRIPTION
clipboard-rs upgrade:
- https://github.com/ChurchTao/clipboard-rs/releases/tag/v0.1.11
- https://github.com/ChurchTao/clipboard-rs/releases/tag/v0.1.10
- https://github.com/ChurchTao/clipboard-rs/releases/tag/v0.1.9
- https://github.com/ChurchTao/clipboard-rs/releases/tag/v0.1.8